### PR TITLE
Vary command phrases

### DIFF
--- a/regex/en-us/item.name.rx
+++ b/regex/en-us/item.name.rx
@@ -1,1 +1,1 @@
-(add|create|remove) (?P<item_name>.*) (to|from) (my|the)
+(add|create|remove) (?P<item_name>.*) (to|from|on|) (my|the|)

--- a/vocab/en-us/add.voc
+++ b/vocab/en-us/add.voc
@@ -1,2 +1,3 @@
 add
 create
+put

--- a/vocab/en-us/del.voc
+++ b/vocab/en-us/del.voc
@@ -1,1 +1,2 @@
 remove
+delete


### PR DESCRIPTION
I am not 100% sure with the syntax and the development process. The changeset might not be complete to be functional working. So I would be glad if you could test my changes.

I wanted to add more options to phrase a command.

"delete" was not a supported key word, like:
`"delete" coffee from my shopping list.`

"put" something "on" a list was not supported, like:
`"put" coffee on my shopping list.` 

If you speak like a computer it should be possible to name a list without a pre-fix (my|the):
`add coffee to shopping list.`

I am not very comfortable with writing and executing python. So I would be very glad if you could add test cases for the new phrases.

I hope you see my suggested changes as an improvement to catch more variety of a natural spoken language, that might also be more approachable to not native english speaking persons.